### PR TITLE
[DEV-2] Post, Comment / Repository, Service 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.5'
@@ -5,6 +10,8 @@ plugins {
 
     id 'jacoco'
     id "org.sonarqube" version "3.5.0.2730"
+    // querydsl plugins
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'radar'
@@ -28,6 +35,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+    implementation 'com.h2database:h2'
+
+    //QueryDSL 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -35,6 +48,25 @@ dependencies {
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
+}
+
+// QueryDSL 추가
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -85,10 +85,29 @@ jacocoTestReport {
         xml.enabled true
         csv.enabled false
     }
+    def Qdomains = []
+    for (qPattern in "**/QA".."**/QZ") {
+        Qdomains.add(qPattern + "*")
+    }
+
+    afterEvaluate {
+
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: [] + Qdomains)
+        }))
+    }
+
     finalizedBy jacocoTestCoverageVerification
 }
 
 jacocoTestCoverageVerification {
+
+    def Qdomains = []
+    for (qPattern in "*.QA".."*.QZ") {
+        Qdomains.add(qPattern + "*")
+    }
+
     violationRules {
         rule {
             element = 'CLASS'
@@ -99,7 +118,7 @@ jacocoTestCoverageVerification {
                 minimum = 0.00
             }
 
-//			excludes("*..*")
+            excludes = [] + Qdomains
         }
     }
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/radar/devmatching/domain/comment/controller/MainCommentController.java
+++ b/src/main/java/radar/devmatching/domain/comment/controller/MainCommentController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 import lombok.RequiredArgsConstructor;
 import radar.devmatching.domain.comment.service.CommentService;
-import radar.devmatching.domain.comment.service.dto.CommentDto;
+import radar.devmatching.domain.comment.service.dto.CreateCommentDto;
 
 @Controller
 @RequiredArgsConstructor
@@ -16,8 +16,9 @@ public class MainCommentController {
 	private final CommentService commentService;
 
 	@PostMapping("posts/{simplePostId}/createMainComment")
-	public String createMainComment(@PathVariable long simplePostId, @ModelAttribute CommentDto commentDto) {
-		commentService.createMainComment(simplePostId, commentDto);
+	public String createMainComment(@PathVariable long simplePostId,
+		@ModelAttribute CreateCommentDto createCommentDto) {
+		// commentService.createMainComment(simplePostId, loginUser, commentDto);
 		return "post/post";
 	}
 

--- a/src/main/java/radar/devmatching/domain/comment/repository/MainCommentRepository.java
+++ b/src/main/java/radar/devmatching/domain/comment/repository/MainCommentRepository.java
@@ -3,6 +3,7 @@ package radar.devmatching.domain.comment.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import radar.devmatching.domain.comment.entity.MainComment;
+import radar.devmatching.domain.comment.repository.custom.MainCommentCustomRepository;
 
-public interface MainCommentRepository extends JpaRepository<MainComment, Long> {
+public interface MainCommentRepository extends JpaRepository<MainComment, Long>, MainCommentCustomRepository {
 }

--- a/src/main/java/radar/devmatching/domain/comment/repository/custom/MainCommentCustomRepository.java
+++ b/src/main/java/radar/devmatching/domain/comment/repository/custom/MainCommentCustomRepository.java
@@ -1,0 +1,11 @@
+package radar.devmatching.domain.comment.repository.custom;
+
+import java.util.List;
+
+import radar.devmatching.domain.comment.entity.MainComment;
+
+public interface MainCommentCustomRepository {
+
+	List<MainComment> getAllComments(long fullPostId);
+
+}

--- a/src/main/java/radar/devmatching/domain/comment/repository/custom/MainCommentRepositoryImpl.java
+++ b/src/main/java/radar/devmatching/domain/comment/repository/custom/MainCommentRepositoryImpl.java
@@ -24,8 +24,8 @@ public class MainCommentRepositoryImpl implements MainCommentCustomRepository {
 	public List<MainComment> getAllComments(long fullPostId) {
 		return queryFactory
 			.selectFrom(mainComment)
-			.leftJoin(comment).fetchJoin()
-			.leftJoin(subComment).fetchJoin()
+			.leftJoin(mainComment.comment, comment).fetchJoin()
+			.leftJoin(mainComment.subComments, subComment).fetchJoin()
 			.where(mainComment.fullPost.id.eq(fullPostId))
 			.fetch();
 	}

--- a/src/main/java/radar/devmatching/domain/comment/repository/custom/MainCommentRepositoryImpl.java
+++ b/src/main/java/radar/devmatching/domain/comment/repository/custom/MainCommentRepositoryImpl.java
@@ -1,0 +1,32 @@
+package radar.devmatching.domain.comment.repository.custom;
+
+import static radar.devmatching.domain.comment.entity.QComment.*;
+import static radar.devmatching.domain.comment.entity.QMainComment.*;
+import static radar.devmatching.domain.comment.entity.QSubComment.*;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import radar.devmatching.domain.comment.entity.MainComment;
+
+public class MainCommentRepositoryImpl implements MainCommentCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public MainCommentRepositoryImpl(EntityManager em) {
+		this.queryFactory = new JPAQueryFactory(em);
+	}
+
+	@Override
+	public List<MainComment> getAllComments(long fullPostId) {
+		return queryFactory
+			.selectFrom(mainComment)
+			.leftJoin(comment).fetchJoin()
+			.leftJoin(subComment).fetchJoin()
+			.where(mainComment.fullPost.id.eq(fullPostId))
+			.fetch();
+	}
+}

--- a/src/main/java/radar/devmatching/domain/comment/service/CommentService.java
+++ b/src/main/java/radar/devmatching/domain/comment/service/CommentService.java
@@ -1,7 +1,13 @@
 package radar.devmatching.domain.comment.service;
 
-import radar.devmatching.domain.comment.service.dto.CommentDto;
+import java.util.List;
+
+import radar.devmatching.domain.comment.service.dto.CreateCommentDto;
+import radar.devmatching.domain.comment.service.dto.MainCommentDto;
+import radar.devmatching.domain.user.entity.User;
 
 public interface CommentService {
-	void createMainComment(long simplePostId, CommentDto commentDto);
+	void createMainComment(long simplePostId, User loginUser, CreateCommentDto createCommentDto);
+
+	List<MainCommentDto> getAllComments(long fullPostId);
 }

--- a/src/main/java/radar/devmatching/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/radar/devmatching/domain/comment/service/CommentServiceImpl.java
@@ -1,14 +1,20 @@
 package radar.devmatching.domain.comment.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import radar.devmatching.domain.comment.entity.MainComment;
 import radar.devmatching.domain.comment.repository.MainCommentRepository;
 import radar.devmatching.domain.comment.repository.SubCommentRepository;
-import radar.devmatching.domain.comment.service.dto.CommentDto;
+import radar.devmatching.domain.comment.service.dto.CreateCommentDto;
+import radar.devmatching.domain.comment.service.dto.MainCommentDto;
 import radar.devmatching.domain.post.entity.SimplePost;
 import radar.devmatching.domain.post.repository.SimplePostRepository;
+import radar.devmatching.domain.user.entity.User;
 
 @Service
 @Transactional(readOnly = true)
@@ -21,9 +27,17 @@ public class CommentServiceImpl implements CommentService {
 
 	@Override
 	@Transactional
-	public void createMainComment(long simplePostId, CommentDto commentDto) {
+	public void createMainComment(long simplePostId, User user, CreateCommentDto createCommentDto) {
 		SimplePost simplePost = simplePostRepository.findById(simplePostId).orElseThrow(() -> new RuntimeException());
-		mainCommentRepository.save(commentDto.toMainCommentEntity(simplePost));
+		mainCommentRepository.save(createCommentDto.toMainCommentEntity(simplePost, user));
+	}
+
+	@Override
+	public List<MainCommentDto> getAllComments(long fullPostId) {
+		List<MainComment> allComments = mainCommentRepository.getAllComments(fullPostId);
+		return allComments.stream()
+			.map(MainCommentDto::of)
+			.collect(Collectors.toList());
 	}
 
 }

--- a/src/main/java/radar/devmatching/domain/comment/service/dto/CommentDto.java
+++ b/src/main/java/radar/devmatching/domain/comment/service/dto/CommentDto.java
@@ -1,28 +1,31 @@
 package radar.devmatching.domain.comment.service.dto;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import radar.devmatching.domain.comment.entity.Comment;
-import radar.devmatching.domain.comment.entity.MainComment;
-import radar.devmatching.domain.post.entity.SimplePost;
+import radar.devmatching.domain.user.service.dto.SimpleUserDto;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentDto {
 
+	private SimpleUserDto simpleUserDto;
+
 	private String content;
 
-	public static CommentDto of() {
-		return new CommentDto();
+	@Builder(access = AccessLevel.PRIVATE)
+	private CommentDto(SimpleUserDto simpleUserDto, String content) {
+		this.simpleUserDto = simpleUserDto;
+		this.content = content;
 	}
 
-	public MainComment toMainCommentEntity(SimplePost simplePost) {
-		return MainComment.builder()
-			.fullPost(
-				simplePost.getFullPost()
-			).comment(
-				Comment.builder().content(this.content).build()
-			).build();
+	public static CommentDto of(Comment comment) {
+		return CommentDto.builder()
+			.simpleUserDto(SimpleUserDto.of(comment.getUser()))
+			.content(comment.getContent())
+			.build();
 	}
+
 }

--- a/src/main/java/radar/devmatching/domain/comment/service/dto/CreateCommentDto.java
+++ b/src/main/java/radar/devmatching/domain/comment/service/dto/CreateCommentDto.java
@@ -1,0 +1,32 @@
+package radar.devmatching.domain.comment.service.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import radar.devmatching.domain.comment.entity.Comment;
+import radar.devmatching.domain.comment.entity.MainComment;
+import radar.devmatching.domain.post.entity.SimplePost;
+import radar.devmatching.domain.user.entity.User;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateCommentDto {
+
+	private String content;
+
+	public static CreateCommentDto of() {
+		return new CreateCommentDto();
+	}
+
+	public MainComment toMainCommentEntity(SimplePost simplePost, User user) {
+		return MainComment.builder()
+			.fullPost(
+				simplePost.getFullPost()
+			).comment(
+				Comment.builder()
+					.content(this.content)
+					.user(user)
+					.build()
+			).build();
+	}
+}

--- a/src/main/java/radar/devmatching/domain/comment/service/dto/MainCommentDto.java
+++ b/src/main/java/radar/devmatching/domain/comment/service/dto/MainCommentDto.java
@@ -1,0 +1,36 @@
+package radar.devmatching.domain.comment.service.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import radar.devmatching.domain.comment.entity.MainComment;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MainCommentDto {
+
+	private CommentDto mainCommentDto;
+
+	private List<CommentDto> subCommentDtos;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private MainCommentDto(CommentDto mainCommentDto, List<CommentDto> subCommentDtos) {
+		this.mainCommentDto = mainCommentDto;
+		this.subCommentDtos = subCommentDtos;
+	}
+
+	public static MainCommentDto of(MainComment mainComment) {
+		return MainCommentDto.builder()
+			.mainCommentDto(CommentDto.of(mainComment.getComment()))
+			.subCommentDtos(
+				mainComment.getSubComments()
+					.stream()
+					.map(subComment -> CommentDto.of(subComment.getComment()))
+					.collect(Collectors.toList())
+			).build();
+	}
+}

--- a/src/main/java/radar/devmatching/domain/matchings/matching/entity/Matching.java
+++ b/src/main/java/radar/devmatching/domain/matchings/matching/entity/Matching.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
@@ -30,7 +29,7 @@ public class Matching extends BaseEntity {
 	@Column(name = "matching_id")
 	private Long id;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(mappedBy = "matching")
 	private SimplePost simplePost;
 
 	// Matching 삭제시 MatchingUser 삭제

--- a/src/main/java/radar/devmatching/domain/post/controller/FullPostController.java
+++ b/src/main/java/radar/devmatching/domain/post/controller/FullPostController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,8 @@ import radar.devmatching.domain.comment.service.CommentService;
 import radar.devmatching.domain.comment.service.dto.MainCommentDto;
 import radar.devmatching.domain.post.entity.SimplePost;
 import radar.devmatching.domain.post.service.PostService;
+import radar.devmatching.domain.post.service.dto.PresentFullPostDto;
+import radar.devmatching.domain.post.service.dto.UpdatePostDto;
 
 @Controller
 @RequiredArgsConstructor
@@ -24,21 +27,39 @@ public class FullPostController {
 	private final CommentService commentService;
 
 	@GetMapping("/{simplePostId}")
-	public String getPost(@PathVariable long simplePostId, Model model) {
-		SimplePost simplePost = postService.getPost(simplePostId);
-		List<MainCommentDto> allComments = commentService.getAllComments(simplePost.getFullPost().getId());
+	public String getFullPost(@PathVariable long simplePostId, Model model) {
+		SimplePost findPost = postService.getPost(simplePostId);
+
+		// TODO: simplePostId에 해당하는 apply 중 state가 수락인 apply count() 반환
+		// int applyCount = applyService.getApplicationNum(simplePostId);
+
+		// if (findPost.getWriter().getId() != user.getId())
+		//	TODO: simplePostId에 해당하는 apply 중 userID가 같은 applyList 반환(게시글에 들어가면 내가 신청한 신청 현환을 볼 수 있다)
+		//	List<신청DTO> list = applyService.get~~(simplePostID, userId);
+
+		List<MainCommentDto> allComments = commentService.getAllComments(findPost.getFullPost().getId());
+
+		model.addAttribute("PresentFullPostDto", PresentFullPostDto.of(findPost));
+		// model.addAttribute("isWriter", findPost.getWriter() == user.getId())
+		// model.addAttribute("applyCount", applyCount);
+		// model.addAttribute("신청DTO", list);
 		model.addAttribute("allComments", allComments);
 		return "post/post";
 	}
 
 	@GetMapping("/{simplePostId}/edit")
-	public String getUpdatePost(@PathVariable long simplePostId) {
+	public String getUpdatePost(@PathVariable long simplePostId, Model model) {
+		SimplePost findPost = postService.getPost(simplePostId);
+
+		model.addAttribute("UpdatePostDto", UpdatePostDto.of(findPost));
 		return "post/editPost";
 	}
 
 	@PostMapping("/{simplePostId}/edit")
-	public String updatePost(@PathVariable long simplePostId) {
-		return "post/editPost";
+	public String updatePost(@PathVariable long simplePostId, @ModelAttribute UpdatePostDto updatePostDto) {
+		postService.updatePost(simplePostId, updatePostDto);
+
+		return "post/post";
 	}
 
 	@PostMapping("/{simplePostId}/delete")

--- a/src/main/java/radar/devmatching/domain/post/controller/FullPostController.java
+++ b/src/main/java/radar/devmatching/domain/post/controller/FullPostController.java
@@ -1,5 +1,7 @@
 package radar.devmatching.domain.post.controller;
 
+import java.util.List;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,7 +10,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import lombok.RequiredArgsConstructor;
-import radar.devmatching.domain.comment.service.dto.CommentDto;
+import radar.devmatching.domain.comment.service.CommentService;
+import radar.devmatching.domain.comment.service.dto.MainCommentDto;
+import radar.devmatching.domain.post.entity.SimplePost;
 import radar.devmatching.domain.post.service.PostService;
 
 @Controller
@@ -17,16 +21,24 @@ import radar.devmatching.domain.post.service.PostService;
 public class FullPostController {
 
 	private final PostService postService;
+	private final CommentService commentService;
 
 	@GetMapping("/{simplePostId}")
 	public String getPost(@PathVariable long simplePostId, Model model) {
-		model.addAttribute("createCommentDto", CommentDto.of());
+		SimplePost simplePost = postService.getPost(simplePostId);
+		List<MainCommentDto> allComments = commentService.getAllComments(simplePost.getFullPost().getId());
+		model.addAttribute("allComments", allComments);
 		return "post/post";
+	}
+
+	@GetMapping("/{simplePostId}/edit")
+	public String getUpdatePost(@PathVariable long simplePostId) {
+		return "post/editPost";
 	}
 
 	@PostMapping("/{simplePostId}/edit")
 	public String updatePost(@PathVariable long simplePostId) {
-		return "post/post";
+		return "post/editPost";
 	}
 
 	@PostMapping("/{simplePostId}/delete")

--- a/src/main/java/radar/devmatching/domain/post/controller/SimplePostController.java
+++ b/src/main/java/radar/devmatching/domain/post/controller/SimplePostController.java
@@ -32,13 +32,13 @@ public class SimplePostController {
 
 	@GetMapping("/my")
 	public String getMyPosts() {
-		// List<SimplePost> myPosts = postService.getMyPost(loginUser.getId());
+		// List<PresentSimplePostDto> myPosts = postService.getMyPosts(loginUser.getId());
 		return "post/myPosts";
 	}
 
 	@GetMapping("/applicationPosts")
 	public String getApplicationPosts() {
-		// postService.getApplicationPosts(user);
+		// List<PresentSimplePostDto> applicationPosts = postService.getApplicationPosts(user);
 		return "post/applicationPosts";
 	}
 

--- a/src/main/java/radar/devmatching/domain/post/entity/FullPost.java
+++ b/src/main/java/radar/devmatching/domain/post/entity/FullPost.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
@@ -32,7 +31,7 @@ public class FullPost extends BaseEntity {
 
 	private String content;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(mappedBy = "fullPost")
 	private SimplePost simplePost;
 
 	@OneToMany(mappedBy = "fullPost", orphanRemoval = true)

--- a/src/main/java/radar/devmatching/domain/post/entity/FullPost.java
+++ b/src/main/java/radar/devmatching/domain/post/entity/FullPost.java
@@ -46,4 +46,8 @@ public class FullPost extends BaseEntity {
 	public void setSimplePost(SimplePost simplePost) {
 		this.simplePost = simplePost;
 	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
 }

--- a/src/main/java/radar/devmatching/domain/post/entity/SimplePost.java
+++ b/src/main/java/radar/devmatching/domain/post/entity/SimplePost.java
@@ -87,4 +87,12 @@ public class SimplePost extends BaseEntity {
 
 		this.applyList = new ArrayList<>();
 	}
+
+	public void update(String title, PostCategory category, Region region, Integer userNum, String content) {
+		this.title = title;
+		this.category = category;
+		this.region = region;
+		this.userNum = userNum;
+		this.fullPost.updateContent(content);
+	}
 }

--- a/src/main/java/radar/devmatching/domain/post/entity/SimplePost.java
+++ b/src/main/java/radar/devmatching/domain/post/entity/SimplePost.java
@@ -55,14 +55,14 @@ public class SimplePost extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
-	private User user;
+	private User writer;
 
 	//SimplePost가 FullPost의 생명주기를 관리한다. (FullPost 삭제 시 Comment들도 전부 자동 삭제됨)
-	@OneToOne(mappedBy = "simplePost", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	private FullPost fullPost;
 
 	//SimplePost가 Matching의 생명주기를 관리한다. (Matching 삭제 시 MatchingUser들도 전부 삭제됨)
-	@OneToOne(mappedBy = "simplePost", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	private Matching matching;
 
 	// simplePost가 Apply의 생명주기를 관리한다.
@@ -70,14 +70,14 @@ public class SimplePost extends BaseEntity {
 	private List<Apply> applyList;
 
 	@Builder
-	public SimplePost(String title, PostCategory category, Region region, Integer userNum, User user,
+	public SimplePost(String title, PostCategory category, Region region, Integer userNum, User writer,
 		FullPost fullPost) {
 		this.title = title;
 		this.category = category;
 		this.region = region;
 		this.userNum = userNum;
 		this.postState = PostState.RECRUITING;
-		this.user = user;
+		this.writer = writer;
 		this.fullPost = fullPost;
 		fullPost.setSimplePost(this);
 

--- a/src/main/java/radar/devmatching/domain/post/repository/SimplePostRepository.java
+++ b/src/main/java/radar/devmatching/domain/post/repository/SimplePostRepository.java
@@ -1,7 +1,9 @@
 package radar.devmatching.domain.post.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,8 +11,11 @@ import radar.devmatching.domain.post.entity.SimplePost;
 
 public interface SimplePostRepository extends JpaRepository<SimplePost, Long> {
 
-	List<SimplePost> findMyPostByUserId(Long userId);
+	List<SimplePost> findMyPostsByWriterId(long userId);
 
 	@Query("select a.applySimplePost from Apply a where a.applyUser.id = :userId")
-	List<SimplePost> findApplicationPosts(Long userId);
+	List<SimplePost> findApplicationPosts(long userId);
+
+	@EntityGraph(attributePaths = {"fullPost"})
+	Optional<SimplePost> findPostById(long simplePostId);
 }

--- a/src/main/java/radar/devmatching/domain/post/service/PostService.java
+++ b/src/main/java/radar/devmatching/domain/post/service/PostService.java
@@ -4,15 +4,21 @@ import java.util.List;
 
 import radar.devmatching.domain.post.entity.SimplePost;
 import radar.devmatching.domain.post.service.dto.CreatePostDto;
+import radar.devmatching.domain.post.service.dto.PresentSimplePostDto;
+import radar.devmatching.domain.post.service.dto.UpdatePostDto;
 import radar.devmatching.domain.user.entity.User;
 
 public interface PostService {
 
 	SimplePost createPost(CreatePostDto createPostDto, User user);
 
-	List<SimplePost> getMyPosts(long userId);
+	List<PresentSimplePostDto> getMyPosts(long userId);
 
-	List<SimplePost> findApplicationPost(long userId);
+	List<PresentSimplePostDto> getApplicationPosts(long userId);
+
+	SimplePost getSimplePostOnly(long simplePostId);
 
 	SimplePost getPost(long simplePostId);
+
+	void updatePost(long simplePostId, UpdatePostDto updatePostDto);
 }

--- a/src/main/java/radar/devmatching/domain/post/service/PostService.java
+++ b/src/main/java/radar/devmatching/domain/post/service/PostService.java
@@ -13,4 +13,6 @@ public interface PostService {
 	List<SimplePost> getMyPosts(long userId);
 
 	List<SimplePost> findApplicationPost(long userId);
+
+	SimplePost getPost(long simplePostId);
 }

--- a/src/main/java/radar/devmatching/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/radar/devmatching/domain/post/service/PostServiceImpl.java
@@ -1,6 +1,7 @@
 package radar.devmatching.domain.post.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +11,8 @@ import radar.devmatching.domain.post.entity.SimplePost;
 import radar.devmatching.domain.post.repository.FullPostRepository;
 import radar.devmatching.domain.post.repository.SimplePostRepository;
 import radar.devmatching.domain.post.service.dto.CreatePostDto;
+import radar.devmatching.domain.post.service.dto.PresentSimplePostDto;
+import radar.devmatching.domain.post.service.dto.UpdatePostDto;
 import radar.devmatching.domain.user.entity.User;
 
 @Service
@@ -21,8 +24,21 @@ public class PostServiceImpl implements PostService {
 	private final FullPostRepository fullPostRepository;
 
 	@Override
-	public SimplePost getPost(long simplePostId) {
+	public SimplePost getSimplePostOnly(long simplePostId) {
 		return simplePostRepository.findById(simplePostId).orElseThrow(() -> new RuntimeException());
+	}
+
+	@Override
+	public SimplePost getPost(long simplePostId) {
+		return simplePostRepository.findPostById(simplePostId).orElseThrow(() -> new RuntimeException());
+	}
+
+	//테스트
+	@Override
+	public void updatePost(long simplePostId, UpdatePostDto updatePostDto) {
+		SimplePost findPost = simplePostRepository.findPostById(simplePostId).orElseThrow(() -> new RuntimeException());
+		findPost.update(updatePostDto.getTitle(), updatePostDto.getCategory(), updatePostDto.getRegion(),
+			updatePostDto.getUserNum(), updatePostDto.getContent());
 	}
 
 	@Override
@@ -32,13 +48,15 @@ public class PostServiceImpl implements PostService {
 	}
 
 	@Override
-	public List<SimplePost> getMyPosts(long userId) {
-		return simplePostRepository.findMyPostByUserId(userId);
+	public List<PresentSimplePostDto> getMyPosts(long userId) {
+		List<SimplePost> myPosts = simplePostRepository.findMyPostsByWriterId(userId);
+		return myPosts.stream().map(PresentSimplePostDto::of).collect(Collectors.toList());
 	}
 
 	@Override
-	public List<SimplePost> findApplicationPost(long userId) {
-		return simplePostRepository.findApplicationPosts(userId);
+	public List<PresentSimplePostDto> getApplicationPosts(long userId) {
+		List<SimplePost> applicationPosts = simplePostRepository.findApplicationPosts(userId);
+		return applicationPosts.stream().map(PresentSimplePostDto::of).collect(Collectors.toList());
 	}
 
 }

--- a/src/main/java/radar/devmatching/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/radar/devmatching/domain/post/service/PostServiceImpl.java
@@ -21,6 +21,11 @@ public class PostServiceImpl implements PostService {
 	private final FullPostRepository fullPostRepository;
 
 	@Override
+	public SimplePost getPost(long simplePostId) {
+		return simplePostRepository.findById(simplePostId).orElseThrow(() -> new RuntimeException());
+	}
+
+	@Override
 	@Transactional
 	public SimplePost createPost(CreatePostDto createPostDto, User user) {
 		return simplePostRepository.save(createPostDto.toEntity(user));

--- a/src/main/java/radar/devmatching/domain/post/service/dto/CreatePostDto.java
+++ b/src/main/java/radar/devmatching/domain/post/service/dto/CreatePostDto.java
@@ -22,8 +22,8 @@ public class CreatePostDto {
 
 	private String content;
 
-	@Builder
-	public CreatePostDto(String title, PostCategory category, Region region, String content) {
+	@Builder(access = AccessLevel.PRIVATE)
+	private CreatePostDto(String title, PostCategory category, Region region, String content) {
 		this.title = title;
 		this.category = category;
 		this.region = region;

--- a/src/main/java/radar/devmatching/domain/post/service/dto/PresentFullPostDto.java
+++ b/src/main/java/radar/devmatching/domain/post/service/dto/PresentFullPostDto.java
@@ -1,0 +1,53 @@
+package radar.devmatching.domain.post.service.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import radar.devmatching.domain.post.entity.PostCategory;
+import radar.devmatching.domain.post.entity.Region;
+import radar.devmatching.domain.post.entity.SimplePost;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PresentFullPostDto {
+
+	private String title;
+
+	private PostCategory category;
+
+	private Region region;
+
+	private Integer userNum;
+
+	private LocalDateTime createDate;
+
+	private String content;
+
+	// private Long clickNum; 조회수는 나중에 추가할게
+
+	@Builder
+	private PresentFullPostDto(String title, PostCategory category, Region region, Integer userNum,
+		LocalDateTime createDate,
+		String content) {
+		this.title = title;
+		this.category = category;
+		this.region = region;
+		this.userNum = userNum;
+		this.createDate = createDate;
+		this.content = content;
+	}
+
+	public static PresentFullPostDto of(SimplePost simplePost) {
+		return PresentFullPostDto.builder()
+			.title(simplePost.getTitle())
+			.category(simplePost.getCategory())
+			.region(simplePost.getRegion())
+			.userNum(simplePost.getUserNum())
+			.createDate(simplePost.getCreateDate())
+			.content(simplePost.getFullPost().getContent())
+			.build();
+	}
+}

--- a/src/main/java/radar/devmatching/domain/post/service/dto/PresentSimplePostDto.java
+++ b/src/main/java/radar/devmatching/domain/post/service/dto/PresentSimplePostDto.java
@@ -1,0 +1,52 @@
+package radar.devmatching.domain.post.service.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import radar.devmatching.domain.post.entity.PostCategory;
+import radar.devmatching.domain.post.entity.Region;
+import radar.devmatching.domain.post.entity.SimplePost;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PresentSimplePostDto {
+
+	private String title;
+
+	private PostCategory category;
+
+	private Region region;
+
+	private Integer userNum;
+
+	private LocalDateTime createDate;
+
+	// private Long clickNum; 조회수는 나중에 추가할게
+
+	@Builder
+	private PresentSimplePostDto(String title, PostCategory category, Region region, Integer userNum,
+		LocalDateTime createDate) {
+		this.title = title;
+		this.category = category;
+		this.region = region;
+		this.userNum = userNum;
+		this.createDate = createDate;
+	}
+
+	public static PresentSimplePostDto of(SimplePost simplePost) {
+		return PresentSimplePostDto.builder()
+			.title(simplePost.getTitle())
+			.category(simplePost.getCategory())
+			.region(simplePost.getRegion())
+			.userNum(simplePost.getUserNum())
+			.createDate(simplePost.getCreateDate())
+			.build();
+	}
+
+	public SimplePost toEntity() {
+		return null;
+	}
+}

--- a/src/main/java/radar/devmatching/domain/post/service/dto/UpdatePostDto.java
+++ b/src/main/java/radar/devmatching/domain/post/service/dto/UpdatePostDto.java
@@ -4,15 +4,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import radar.devmatching.domain.post.entity.FullPost;
 import radar.devmatching.domain.post.entity.PostCategory;
 import radar.devmatching.domain.post.entity.Region;
 import radar.devmatching.domain.post.entity.SimplePost;
-import radar.devmatching.domain.user.entity.User;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class CreatePostDto {
+public class UpdatePostDto {
 
 	private String title;
 
@@ -20,31 +18,27 @@ public class CreatePostDto {
 
 	private Region region;
 
+	private Integer userNum;
+
 	private String content;
 
 	@Builder
-	private CreatePostDto(String title, PostCategory category, Region region, String content) {
+	private UpdatePostDto(String title, PostCategory category, Region region, Integer userNum, String content) {
 		this.title = title;
 		this.category = category;
 		this.region = region;
+		this.userNum = userNum;
 		this.content = content;
 	}
 
-	public static CreatePostDto of() {
-		return new CreatePostDto();
+	public static UpdatePostDto of(SimplePost simplePost) {
+		return UpdatePostDto.builder()
+			.title(simplePost.getTitle())
+			.category(simplePost.getCategory())
+			.region(simplePost.getRegion())
+			.userNum(simplePost.getUserNum())
+			.content(simplePost.getFullPost().getContent())
+			.build();
 	}
 
-	public SimplePost toEntity(User user) {
-		return SimplePost.builder()
-			.title(this.title)
-			.category(this.category)
-			.region(this.region)
-			.userNum(1)
-			.writer(user)
-			.fullPost(
-				FullPost.builder().
-					content(this.content)
-					.build()
-			).build();
-	}
 }

--- a/src/main/java/radar/devmatching/domain/user/entity/User.java
+++ b/src/main/java/radar/devmatching/domain/user/entity/User.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 import radar.devmatching.common.entity.BaseEntity;
 import radar.devmatching.domain.matchings.apply.entity.Apply;
 import radar.devmatching.domain.matchings.matchinguser.entity.MatchingUser;
+import radar.devmatching.domain.post.entity.SimplePost;
 
 // USER로 하니 에러떠서 복수형으로 바꿈(더 좋은 방안 없으려나)
 @Table(name = "USERS")
@@ -62,6 +63,10 @@ public class User extends BaseEntity {
 	@OneToMany(mappedBy = "applyUser", orphanRemoval = true)
 	private List<Apply> applyList;
 
+	// User 삭제 시 SimplePost도 삭제
+	@OneToMany(mappedBy = "writer", orphanRemoval = true)
+	private List<SimplePost> simplePosts;
+
 	@Builder
 	public User(String username, String password, String nickName, String schoolName, String githubUrl,
 		String introduce) {
@@ -74,6 +79,7 @@ public class User extends BaseEntity {
 		this.userRole = UserRole.ROLE_USER;
 		this.matchingUsers = new ArrayList<>();
 		this.applyList = new ArrayList<>();
+		this.simplePosts = new ArrayList<>();
 	}
 
 	@Override

--- a/src/main/java/radar/devmatching/domain/user/service/dto/SimpleUserDto.java
+++ b/src/main/java/radar/devmatching/domain/user/service/dto/SimpleUserDto.java
@@ -1,0 +1,45 @@
+package radar.devmatching.domain.user.service.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import radar.devmatching.domain.user.entity.User;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SimpleUserDto {
+
+	private String username;
+
+	private String nickname;
+
+	private String schoolName;
+
+	private String githubUrl;
+
+	private String introduce;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private SimpleUserDto(String username, String nickname, String schoolName, String githubUrl, String introduce) {
+		this.username = username;
+		this.nickname = nickname;
+		this.schoolName = schoolName;
+		this.githubUrl = githubUrl;
+		this.introduce = introduce;
+	}
+
+	public static SimpleUserDto of() {
+		return new SimpleUserDto();
+	}
+
+	public static SimpleUserDto of(User user) {
+		return SimpleUserDto.builder()
+			.username(user.getUsername())
+			.nickname(user.getNickName())
+			.schoolName(user.getSchoolName())
+			.githubUrl(user.getGithubUrl())
+			.introduce(user.getIntroduce())
+			.build();
+	}
+}

--- a/src/main/resources/templates/post/editPost.html
+++ b/src/main/resources/templates/post/editPost.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html th:replace="~{layout :: layout(~{::main})}" xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<main>
+    <div class="col-xl-6">
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fas fa-chart-bar me-1"></i>
+                게시글
+            </div>
+            <div class="card-body">
+                <canvas height="200" width="50"></canvas>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+
+</html>

--- a/src/test/java/radar/devmatching/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/radar/devmatching/domain/post/service/PostServiceImplTest.java
@@ -20,6 +20,7 @@ import radar.devmatching.domain.post.entity.SimplePost;
 import radar.devmatching.domain.post.repository.FullPostRepository;
 import radar.devmatching.domain.post.repository.SimplePostRepository;
 import radar.devmatching.domain.post.service.dto.CreatePostDto;
+import radar.devmatching.domain.post.service.dto.PresentSimplePostDto;
 import radar.devmatching.domain.user.entity.User;
 import radar.devmatching.domain.user.repository.UserRepository;
 
@@ -52,7 +53,7 @@ class PostServiceImplTest {
 			.category(PostCategory.PROJECT)
 			.region(Region.BUSAN)
 			.userNum(1)
-			.user(loginUser)
+			.writer(loginUser)
 			.fullPost(FullPost.builder().content("내용").build())
 			.build();
 	}
@@ -67,17 +68,31 @@ class PostServiceImplTest {
 	}
 
 	@Test
-	@DisplayName("getMyPost메서드는 내 유저 아이디가 인자로 들어오면 내가 게시한 게시글들을 반환한다")
-	void getMyPostTest() throws Exception {
+	@DisplayName("getMyPosts메서드는 내 유저 아이디가 인자로 들어오면 내가 게시한 SimplePost들을 반환한다")
+	void getMyPostsTest() throws Exception {
 		//given
-		SimplePost simplePost = createSimplePost();
-		given(simplePostRepository.findMyPostByUserId(any())).willReturn(List.of(simplePost));
+		SimplePost myPost = createSimplePost();
+		given(simplePostRepository.findMyPostsByWriterId(1L)).willReturn(List.of(myPost));
 
 		//when
-		List<SimplePost> myPost = postService.getMyPosts(1L);
+		List<PresentSimplePostDto> findPosts = postService.getMyPosts(1L);
 
 		//then
-		assertThat(simplePost).isEqualTo(myPost.get(0));
+		assertThat(PresentSimplePostDto.of(myPost)).usingRecursiveComparison().isEqualTo(findPosts.get(0));
+	}
+
+	@Test
+	@DisplayName("getApplicationPosts 메서드는 내 유저 아이디가 인자로 들어오면 내가 신청한 SimplePost들을 반환한다.")
+	void getApplicationPostsTest() throws Exception {
+		//given
+		SimplePost appliedPost = createSimplePost();
+		given(simplePostRepository.findApplicationPosts(1L)).willReturn(List.of(appliedPost));
+
+		//when
+		List<PresentSimplePostDto> findPosts = postService.getApplicationPosts(1L);
+
+		//then
+		assertThat(PresentSimplePostDto.of(appliedPost)).usingRecursiveComparison().isEqualTo(findPosts.get(0));
 	}
 
 	@Nested
@@ -95,6 +110,7 @@ class PostServiceImplTest {
 				CreatePostDto createPostDto = createPostDto();
 				SimplePost simplePost = createSimplePost();
 
+				//simplePostRepository.save시 FullPost와 Matching 엔티티도 만들어져 저장된다.
 				given(simplePostRepository.save(any(SimplePost.class))).willReturn(simplePost);
 
 				//when


### PR DESCRIPTION
QueryDSL 추가함

우리 리포지토리는 Data JPA랑 querydsl이랑 합쳐도 될 듯(querydsl로 특정 부분에 특화된 작업을 하는게 아니라 굳이 안 나누어도 될 것 같음)

apply구현 부분 todo 나중에 시간나면 구현 부탁해요~

서비스에서 무조건 엔티티를 DTO로 변경해서 넘기는건 구현할 때 오히려 힘들어져서 엔티티 -> DTO 변경은 컨트롤러단에서도 가능하게 하는거 어떰? (FullPostController의 getFullPost() 참고)